### PR TITLE
Add missing line from disclaimers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 A serverless application for analyzing public comments from regulations.gov using advanced NLP techniques, clustering, and AI-powered insights.
 
+## Disclaimers
+Customers are responsible for making their own independent assessment of the information in this document.
+
+This document:
+
+(a) is for informational purposes only,
+
+(b) references AWS product offerings and practices, which are subject to change without notice,
+
+(c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. AWS products or services are provided "as is" without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers, and
+
+(d) is not to be considered a recommendation or viewpoint of AWS.
+
+Additionally, you are solely responsible for testing, security and optimizing all code and assets on GitHub repo, and all such code and assets should be considered:
+
+(a) as-is and without warranties or representations of any kind,
+
+(b) not suitable for production environments, or on production or other critical data, and
+
+(c) to include shortcuts in order to support rapid prototyping such as, but not limited to, relaxed authentication and authorization and a lack of strict adherence to security best practices.
+
+All work produced is open source. More information can be found in the GitHub repo.
+
 ## Disclaimers 
 
 Customers are responsible for making their own independent assessment of the information in this document.

--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ Additionally, you are solely responsible for testing, security and optimizing al
 
 All work produced is open source. More information can be found in the GitHub repo.
 
-## Disclaimers 
-
-Customers are responsible for making their own independent assessment of the information in this document.
-This document:
-- (a) is for informational purposes only,
-- (b) references AWS product offerings and practices, which are subject to change without notice,
-- (c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. AWS products or services are provided “as is” without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers, and
-- (d) is not to be considered a recommendation or viewpoint of AWS.
-  
-Additionally, you are solely responsible for testing, security and optimizing all code and assets on GitHub repo, and all such code and assets should be considered:
-- (a) as-is and without warranties or representations of any kind,
-- (b) not suitable for production environments, or on production or other critical data, and
-- (c) to include shortcuts in order to support rapid prototyping such as, but not limited to, relaxed authentication and authorization and a lack of strict adherence to security best practices.
-
 ## Project Overview
 
 The USDA Public Comment Analysis system ingests public comments from regulations.gov, processes them using advanced natural language processing techniques, and generates insightful reports that include topic modeling, sentiment analysis, and detection of AI-generated content. This system assists USDA staff in efficiently analyzing public feedback on proposed regulations.


### PR DESCRIPTION
Last line "All work produced is open source. More information can be found in the GitHub repo." was missing from the disclaimers section.